### PR TITLE
Fix typo: fails on case-sensitive platforms

### DIFF
--- a/Mochie/Uber Shader/USDefines.cginc
+++ b/Mochie/Uber Shader/USDefines.cginc
@@ -7,7 +7,7 @@
 #include "../Common/Color.cginc"
 #include "../Common/Utilities.cginc"
 #include "../Common/Noise.cginc"
-#include "Autolight.cginc"
+#include "AutoLight.cginc"
 
 MOCHIE_DECLARE_TEX2D(_MainTex);
 float4 _MainTex_ST, _MainTex_TexelSize;


### PR DESCRIPTION
I'm a Linux user, and this typo prevents the shaders from compiling properly.