### PR TITLE
Add AreaLit Occlusion Lightmap UV fix.

### DIFF
--- a/Mochie/Standard Shader/MochieStandardInput.cginc
+++ b/Mochie/Standard Shader/MochieStandardInput.cginc
@@ -312,7 +312,7 @@ void InitializeAudioLink(inout audioLinkData al, float time){
 
 float2 SelectUVSet(VertexInput v, int selection, int swizzle, float3 worldPos){
 	if (selection < 5){
-		float2 uvs[] = {v.uv0, v.uv1, v.uv2, v.uv3, v.uv4};
+		float2 uvs[] = {v.uv0, v.uv1, v.uv2, v.uv3, v.uv4, v.uv1 * unity_LightmapST.xy + unity_LightmapST.zw};
 		return uvs[selection];
 	}
 	else {

--- a/Mochie/Standard Shader/Standard.shader
+++ b/Mochie/Standard Shader/Standard.shader
@@ -234,7 +234,7 @@ Shader "Mochie/Standard" {
 		[ToggleOff]_OpaqueLights("Opaque Lights", Float) = 1.0
 
 		_AreaLitOcclusion("Occlusion", 2D) = "white" {}
-		[Enum(UV0,0,UV1,1, UV2,2, UV3,3, UV4,4)]_OcclusionUVSet("UV Set for occlusion map", Float) = 0
+		[Enum(UV0,0,UV1,1, UV2,2, UV3,3, UV4,4, UV1_LightmapST,5)]_OcclusionUVSet("UV Set for occlusion map", Float) = 0
 
         [HideInInspector]_SrcBlend("__src", Float) = 1.0
         [HideInInspector]_DstBlend("__dst", Float) = 0.0

--- a/Mochie/Unity/Prefabs/Default.mat.meta
+++ b/Mochie/Unity/Prefabs/Default.mat.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 497f8485774204244abb7ba6c0865927
+guid: bb992c2c64ae58940a6f794761fc324f
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 2100000

--- a/Mochie/Unity/Prefabs/Materials/Screen FX Mat.mat.meta
+++ b/Mochie/Unity/Prefabs/Materials/Screen FX Mat.mat.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 497f8485774204244abb7ba6c0865927
+guid: 38b9abeae069b394fb984f5340869ef7
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 2100000

--- a/Mochie/Unity/Prefabs/Materials/Underwater Mat.mat.meta
+++ b/Mochie/Unity/Prefabs/Materials/Underwater Mat.mat.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8d3f0d345ef88514794c6c74d5e23212
+guid: 38e4fc70066cf3741b410dc61dc22179
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 2100000

--- a/Mochie/Unity/Prefabs/Screen FX Mat.mat.meta
+++ b/Mochie/Unity/Prefabs/Screen FX Mat.mat.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 497f8485774204244abb7ba6c0865927
+guid: d52a9bb41378290438c35cd3bb932d86
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 2100000

--- a/Mochie/Unity/Prefabs/Underwater Mat.mat.meta
+++ b/Mochie/Unity/Prefabs/Underwater Mat.mat.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8d3f0d345ef88514794c6c74d5e23212
+guid: de85b1140701c77488f2f2c7663c33d9
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 2100000

--- a/Mochie/Unity/Textures/Foam 1.jpg.meta
+++ b/Mochie/Unity/Textures/Foam 1.jpg.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6706fbb4d4df9f04eac5dd6ef24e6ecf
+guid: cdab8b2843cefad4ab9538b186cabaf7
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}

--- a/Mochie/Unity/Textures/Foam.jpg.meta
+++ b/Mochie/Unity/Textures/Foam.jpg.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6706fbb4d4df9f04eac5dd6ef24e6ecf
+guid: b7b75f4ad2f7d384b85f2fb75e4b2ca6
 TextureImporter:
   fileIDToRecycleName: {}
   externalObjects: {}

--- a/Mochie/Water Shader/WaterFrag.cginc.meta
+++ b/Mochie/Water Shader/WaterFrag.cginc.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 124202f442c30e247939ed195233070a
+guid: c52331bc47666484bbdd7bbdff470194
 ShaderImporter:
   externalObjects: {}
   defaultTextures: []

--- a/Mochie/Water Shader/WaterPass.cginc.meta
+++ b/Mochie/Water Shader/WaterPass.cginc.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 124202f442c30e247939ed195233070a
+guid: 3e7aba1cf3cca8841b66c49f165fba2d
 ShaderImporter:
   externalObjects: {}
   defaultTextures: []


### PR DESCRIPTION
The original AreaLit occlusion map selection contains a UV map selection that is the second UV channel transformed by Unity's internal lightmapper. This allows for users to have their shadowmasks to be baked in Unity and use the atlas created by Unity's lightmapping system for their shadowmasks. The occlusion map selection contains an option for the second UV channel, but it is not transformed by Unity's internal lightmapper. This is a request to add a 5th option to for Arealit's occlussion map uvs that support the second UV channel transformed by Unity's internal lightmapper.

Here's what a shadowmap baked with the lightmapper looks like applied without the lightmapping transforms:

![](https://imgur.com/zRAvdHR.png)


Here's what it is suppose to look like, with the proper transforms applied

![](https://imgur.com/AdLYqIt.png)


Notice the extra option added for the Occlusion UV Selection.

![](https://imgur.com/9sBXFuG.png)

"Added "v.uv1 * unity_LightmapST.xy + unity_LightmapST.zw" as 5th option to SelectUVSet function. Fixes arealit shadowmasks baked with the unity lightmapper from misaligned with Unity's lightmapping uvs."

