### PR TITLE
World Offset, World Rotation for Triplanar World UV

### DIFF
--- a/Mochie/Standard Shader/Standard.shader
+++ b/Mochie/Standard Shader/Standard.shader
@@ -13,6 +13,11 @@ Shader "Mochie/Standard" {
         [Enum(Off,0, On,1)]_SmoothnessToggle("Use Smoothness", Int) = 0
         [Enum(Local,0, World,1)]_TriplanarCoordSpace("Triplanar Coordinate Space", Int) = 0
 
+        // World Rotation for Triplanar CS PR01
+        _TriplanarWorldRotation("Triplanar World Rotation (XYZ Degrees)", Vector) = (0,0,0,0)
+        _TriplanarWorldOffset("Triplanar World Offset", Vector) = (0,0,0,0)
+        // World Rotation for Triplanar CS PR01 END
+
         // Primary Textures
         [Enum(Separate,0, Packed,1)]_PrimaryWorkflow("Primary Workflow", Int) = 0
         [Enum(Default,0, Stochastic,1, Supersampling,2, Triplanar,3)]_PrimarySampleMode("Primary Sampling Mode", Int) = 0
@@ -329,7 +334,19 @@ Shader "Mochie/Standard" {
         _DefaultDetailSampler("Detail Wrap/Filter Settings", 2D) = "white" {}
         
         // Debug Views
-        [HideInInspector] _DebugFlags("Debug Flags", Integer) = 0
+        [ToggleUI]_DebugEnable("Enable Debug View", Int) = 0
+        [ToggleUI]_DebugVertexColors("Vertex Colors", Int) = 0
+        [ToggleUI]_DebugBaseColor("Base Color", Int) = 1
+        [ToggleUI]_DebugNormals("Normals", Int) = 0
+        [ToggleUI]_DebugRoughness("Roughness", Int) = 0
+        [ToggleUI]_DebugMetallic("Metallic", Int) = 0
+        [ToggleUI]_DebugOcclusion("Occlusion", Int) = 0
+        [ToggleUI]_DebugHeight("Height", Int) = 0
+        [ToggleUI]_DebugAtten("Attenuation", Int) = 0
+        [ToggleUI]_DebugReflections("Reflections", Int) = 0
+        [ToggleUI]_DebugSpecular("Specular Highlights", Int) = 0
+        [ToggleUI]_DebugAlpha("Alpha", Int) = 0
+        [ToggleUI]_DebugLighting("Alpha", Int) = 0
 
         // NO TOUCHY
         [HideInInspector]_SrcBlend("__src", Float) = 1.0
@@ -445,7 +462,6 @@ Shader "Mochie/Standard" {
         Pass {
             Tags {"LightMode" = "ShadowCaster"}
             CGPROGRAM
-            #pragma target 5.0
             #pragma vertex vert
             #pragma fragment frag
             #pragma shader_feature_local _ _ALPHATEST_ON _ALPHABLEND_ON _ALPHAPREMULTIPLY_ON
@@ -470,7 +486,6 @@ Shader "Mochie/Standard" {
             Cull Off
 
             CGPROGRAM
-            #pragma target 5.0
             #pragma vertex vert
             #pragma fragment frag
             #pragma shader_feature_local _ _ALPHATEST_ON _ALPHABLEND_ON _ALPHAPREMULTIPLY_ON

--- a/Mochie/Standard Shader/StandardInput.cginc
+++ b/Mochie/Standard Shader/StandardInput.cginc
@@ -1,6 +1,5 @@
 #ifndef STANDARD_INPUT_INCLUDED
 #define STANDARD_INPUT_INCLUDED
-#include "StandardDefines.cginc"
 
 void InitializeDefaultSampler(out float4 defaultSampler, out float4 defaultDetailSampler){
     defaultSampler = MOCHIE_SAMPLE_TEX2D_SAMPLER(_DefaultSampler, sampler_DefaultSampler, 0) * EPSILON;
@@ -10,35 +9,20 @@ void InitializeDefaultSampler(out float4 defaultSampler, out float4 defaultDetai
     #endif
 }
 
-void apply_debug(int index, inout float4 current, float4 value){
-    bool active = (_DebugFlags & (1 << index)) > 0;
-
-    if (active)
-        current = value;
-}
-
-void apply_debug(int index, inout float4 current, float3 value){
-    apply_debug(index, current, float4(value, 0));
-}
-
 void DebugView(v2f i, InputData id, LightingData ld, inout float4 diffuse){
-    if (_MaterialDebugMode == 1 && _DebugFlags != 0){
-        diffuse = float4(0,0,0,1);
-        apply_debug(0, diffuse, id.baseColor);
-        apply_debug(1, diffuse, id.alpha.rrrr);
-        apply_debug(2, diffuse, id.normal);
-        apply_debug(3, diffuse, id.tsNormal);
-        apply_debug(4, diffuse, id.vNormal);
-        apply_debug(5, diffuse, id.roughness);
-        apply_debug(6, diffuse, id.metallic);
-        apply_debug(7, diffuse, id.occlusion);
-        apply_debug(8, diffuse, id.height);
-        apply_debug(9, diffuse, ld.lightCol);
-        apply_debug(10, diffuse, (ld.atten * ld.NdotL).rrrr);
-        apply_debug(11, diffuse, ld.reflectionCol);
-        apply_debug(12, diffuse, ld.specHighlightCol);
-        apply_debug(13, diffuse, i.color);
-        apply_debug(14, diffuse, saturate(float4(i.wind.xyz, 1)));
+    if (_MaterialDebugMode == 1 && _DebugEnable == 1){
+        diffuse = _DebugBaseColor == 1 ? id.baseColor : float4(0,0,0,1);
+        diffuse.rgb = _DebugAlpha == 1 ? diffuse.rgb + id.alpha : diffuse.rgb;
+        diffuse.rgb = _DebugNormals == 1 ? diffuse.rgb + id.tsNormal : diffuse;
+        diffuse.rgb = _DebugRoughness == 1 ? diffuse.rgb + id.roughness : diffuse;
+        diffuse.rgb = _DebugMetallic == 1 ? diffuse.rgb + id.metallic : diffuse;
+        diffuse.rgb = _DebugOcclusion == 1 ? diffuse.rgb + id.occlusion : diffuse;
+        diffuse.rgb = _DebugHeight == 1 ? diffuse.rgb + id.height : diffuse;
+        diffuse.rgb = _DebugLighting == 1 ? diffuse.rgb + ld.lightCol : diffuse.rgb;
+        diffuse.rgb = _DebugAtten == 1 ? diffuse.rgb + ld.atten * ld.NdotL : diffuse;
+        diffuse.rgb = _DebugReflections == 1 ? diffuse.rgb + ld.reflectionCol : diffuse.rgb;
+        diffuse.rgb = _DebugSpecular == 1 ? diffuse.rgb + ld.specHighlightCol : diffuse.rgb;
+        // diffuse.rgb = _DebugVertexColors == 1 ? diffuse.rgb + i.color : diffuse.rgb;
     }
 }
 
@@ -145,94 +129,46 @@ void InitializeUVs(appdata v, inout v2f o){
         o.uv4.xy = TRANSFORM_TEX(o.uv4.xy, _AreaLitOcclusion);
     #endif
 
-    #if !defined(STANDARD_MOBILE)
-        if (_AlphaSource == 1){
-            o.uv4.zw = ScaleOffsetRotateScrollUV(SelectUVSet(uvs, _UVAlphaMaskSet, _UVAlphaMaskSwizzle, o.worldPos, o.localPos), _AlphaMask_ST.xy, _AlphaMask_ST.zw, _UVAlphaMaskRotation, _UVAlphaMaskScroll);
-        }
+    if (_AlphaSource == 1){
+        o.uv4.zw = ScaleOffsetRotateScrollUV(SelectUVSet(uvs, _UVAlphaMaskSet, _UVAlphaMaskSwizzle, o.worldPos, o.localPos), _AlphaMask_ST.xy, _AlphaMask_ST.zw, _UVAlphaMaskRotation, _UVAlphaMaskScroll);
+    }
 
-        if (_PuddleToggle == 1){
-            o.uv5.xy = ScaleOffsetRotateScrollUV(SelectUVSet(uvs, _UVPuddleSet, _UVPuddleSwizzle, o.worldPos, o.localPos), _PuddleTexture_ST.xy, _PuddleTexture_ST.zw, _UVPuddleRotation, _UVPuddleScroll);
-        }
-    #endif
+    if (_PuddleToggle == 1){
+        o.uv5.xy = ScaleOffsetRotateScrollUV(SelectUVSet(uvs, _UVPuddleSet, _UVPuddleSwizzle, o.worldPos, o.localPos), _PuddleTexture_ST.xy, _PuddleTexture_ST.zw, _UVPuddleRotation, _UVPuddleScroll);
+    }
 }
 
-float4 triplanar_color(Texture2D tex, SamplerState samp, float4 tilingOffset, float blendFactor = 2)
+float4 tex2Dtri(Texture2D tex, SamplerState samp, float4 scaleTransform)
 {
-    float3 surfaceNormal = _TriplanarCoordSpace == 1 ? worldVertexNormal : localVertexNormal;
-    float3 worldPos = _TriplanarCoordSpace == 1 ? worldVertexPos : localVertexPos;
-    
-    float3 blend = pow(abs(surfaceNormal.xyz), blendFactor);
-    blend /= dot(blend, float3(1,1,1));
+    float3 surfaceNormal = (_TriplanarCoordSpace > 0.5) ? abs(worldVertexNormal) : abs(localVertexNormal);
+    float3 pos = (_TriplanarCoordSpace > 0.5) ? worldVertexPos : localVertexPos;
 
-    float4 result = 0;
+    if (_TriplanarCoordSpace > 0.5)
+    {
+        pos = ApplyTriplanarWorldXform(pos);
+    }
 
-    float2 uvX = tilingOffset.xy * worldPos.zy + tilingOffset.zw;
-    float2 uvY = tilingOffset.xy * worldPos.xz + tilingOffset.zw;
-    float2 uvZ = tilingOffset.xy * worldPos.xy + tilingOffset.zw;
+    float3 projectedNormal = surfaceNormal / (surfaceNormal.x + surfaceNormal.y + surfaceNormal.z);
 
-    // these keep a UV checker texture oriented sensibly
-    if (surfaceNormal.x < 0)
-        uvX.x *= -1;
+    float3 normalSign = sign(surfaceNormal);
+    float2 uvX = scaleTransform.xy * (pos.zy * float2(normalSign.x, 1)) + scaleTransform.zw;
+    float2 uvY = scaleTransform.xy * (pos.xz * float2(normalSign.y, 1)) + scaleTransform.zw;
+    float2 uvZ = scaleTransform.xy * (pos.xy * float2(-normalSign.z, 1)) + scaleTransform.zw;
 
-    if (surfaceNormal.z > 0)
-        uvZ.x *= -1;
-    
-    result += blend.x * tex.Sample(samp, uvX);
-    result += blend.y * tex.Sample(samp, uvY);
-    result += blend.z * tex.Sample(samp, uvZ);
+    float4 sampleX = 0;
+    float4 sampleY = 0;
+    float4 sampleZ = 0;
 
-    return result;
+    if (projectedNormal.x > 0)
+        sampleX = MOCHIE_SAMPLE_TEX2D_SAMPLER(tex, samp, uvX);
+    if (projectedNormal.y > 0)
+        sampleY = MOCHIE_SAMPLE_TEX2D_SAMPLER(tex, samp, uvY);
+    if (projectedNormal.z > 0)
+        sampleZ = MOCHIE_SAMPLE_TEX2D_SAMPLER(tex, samp, uvZ);
+
+    return (sampleX * projectedNormal.x) + (sampleY * projectedNormal.y) + (sampleZ * projectedNormal.z);
 }
 
-// bless bgolus
-// https://bgolus.medium.com/normal-mapping-for-a-triplanar-shader-10bf39dca05a
-float3 triplanar_normal(Texture2D tex, SamplerState samp, float4 tilingOffset, float strength, float blendFactor = 2)
-{
-    float3 surfaceNormal = _TriplanarCoordSpace == 1 ? worldVertexNormal : localVertexNormal;
-    float3 worldPos = _TriplanarCoordSpace == 1 ? worldVertexPos : localVertexPos;
-
-    float3 blend = pow(abs(surfaceNormal.xyz), blendFactor);
-    blend /= dot(blend, float3(1,1,1));
-    
-    float2 uvX = tilingOffset.xy * worldPos.zy + tilingOffset.zw;
-    float2 uvY = tilingOffset.xy * worldPos.xz + tilingOffset.zw;
-    float2 uvZ = tilingOffset.xy * worldPos.xy + tilingOffset.zw;
-
-    // th
-    if (surfaceNormal.x < 0)
-        uvX.x *= -1;
-
-    if (surfaceNormal.z > 0)
-        uvZ.x *= -1;
-
-    half3 tnormalX = UnpackScaleNormal(MOCHIE_SAMPLE_TEX2D_SAMPLER(tex, samp, uvX), strength);
-    half3 tnormalY = UnpackScaleNormal(MOCHIE_SAMPLE_TEX2D_SAMPLER(tex, samp, uvY), strength);
-    half3 tnormalZ = UnpackScaleNormal(MOCHIE_SAMPLE_TEX2D_SAMPLER(tex, samp, uvZ), strength);
-
-    if (surfaceNormal.x < 0)
-        tnormalX.x *= -1;
-
-    if (surfaceNormal.z > 0)
-        tnormalZ.x *= -1;
-
-    // this reinterprets the tangent-space normals as
-    // world-space normals
-    half3 normalX = half3(0.0, tnormalX.yx);
-    half3 normalY = half3(tnormalY.x, 0.0, tnormalY.y);
-    half3 normalZ = half3(tnormalZ.xy, 0.0);
-    
-    // Triblend normals and add to world normal
-    float3 result = 
-        normalX.xyz * blend.x +
-        normalY.xyz * blend.y +
-        normalZ.xyz * blend.z +
-        surfaceNormal;
-
-    if (_TriplanarCoordSpace == 0)
-        result = mul((float3x3) unity_ObjectToWorld, result);
-
-    return normalize(result);
-}
 
 // Unused for now - works but has some quirks
 float4 tex2Dbi(Texture2D tex, float k){
@@ -269,7 +205,7 @@ float4 SampleTexture(Texture2D tex, float2 uv){
     #if defined(_STOCHASTIC_ON)
         texSample = tex2Dstoch(tex, sampler_DefaultSampler, uv);
     #elif defined(_TRIPLANAR_ON)
-        texSample = triplanar_color(tex, sampler_DefaultSampler, _MainTex_ST);
+        texSample = tex2Dtri(tex, sampler_DefaultSampler, _MainTex_ST);
     #elif defined(_SUPERSAMPLING_ON)
         texSample = tex2Dsuper(tex, sampler_DefaultSampler, uv);
     #else
@@ -283,7 +219,7 @@ float4 SampleDetailTexture(Texture2D tex, float2 uv){
     #if defined(_STOCHASTIC_DETAIL_ON) || (defined(STANDARD_LITE) && defined(_STOCHASTIC_ON))
         texSample = tex2Dstoch(tex, sampler_DefaultDetailSampler, uv);
     #elif defined(_TRIPLANAR_DETAIL_ON) || (defined(STANDARD_LITE) && defined(_TRIPLANAR_ON))
-        texSample = triplanar_color(tex, sampler_DefaultDetailSampler, _DetailMainTex_ST);
+        texSample = tex2Dtri(tex, sampler_DefaultDetailSampler, _DetailMainTex_ST);
     #elif defined(_SUPERSAMPLING_DETAIL_ON) || (defined(STANDARD_LITE) && defined(_SUPERSAMPLING_ON))
         texSample = tex2Dsuper(tex, sampler_DefaultDetailSampler, uv);
     #else
@@ -326,10 +262,16 @@ float4 SampleDetailBaseColor(float2 uv){
 }
 
 float3 SampleNormalMap(float2 uv){
+    #if defined(_TRIPLANAR_ON)
+        _NormalStrength *= 2;
+    #endif
     return UnpackScaleNormal(SampleTexture(_NormalMap, uv), _NormalStrength);
 }
 
 float3 SampleDetailNormalMap(float2 uv, float mask){
+    #if defined(_TRIPLANAR_DETAIL_ON) || (defined(STANDARD_LITE) && defined(_TRIPLANAR_ON))
+        _DetailNormalStrength *= 2;
+    #endif
     return UnpackScaleNormal(SampleDetailTexture(_DetailNormalMap, uv), _DetailNormalStrength * mask);
 }
 
@@ -396,7 +338,7 @@ float4 GetEmission(v2f i){
     #if defined(META_PASS)
         #if defined(_AUDIOLINK_ON) && defined(_AUDIOLINK_META_ON)
             audioLinkData al = (audioLinkData)0;
-            InitializeAudioLink(al);
+            InitializeAudioLink(al, 0);
             float alMult = GetAudioLinkBand(al, _AudioLinkEmission);
             alMult = Remap(alMult, 0, 1, _AudioLinkMin, _AudioLinkMax);
             emissTex *= lerp(1, alMult, _AudioLinkEmissionStrength * al.textureExists);
@@ -404,7 +346,7 @@ float4 GetEmission(v2f i){
     #else
         #if defined(_AUDIOLINK_ON)
             audioLinkData al = (audioLinkData)0;
-            InitializeAudioLink(al);
+            InitializeAudioLink(al, 0);
             float alMult = GetAudioLinkBand(al, _AudioLinkEmission);
             alMult = Remap(alMult, 0, 1, _AudioLinkMin, _AudioLinkMax);
             emissTex *= lerp(1, alMult, _AudioLinkEmissionStrength * al.textureExists);
@@ -412,52 +354,6 @@ float4 GetEmission(v2f i){
     #endif
 
     return emissTex;
-}
-
-float3 project(float3 a, float3 b)
-{
-    return b * dot(a, b) / dot(b, b);
-}
-
-float3x3 calculate_planar_tbn(float3x3 tangentToWorld, bool localSpace, int swizzle)
-{
-    float3 normal = tangentToWorld[2];
-    float3 tangent = 0;
-    float3 bitangent = 0;
-
-    switch (swizzle)
-    {
-    case 0:
-        tangent.x = bitangent.y = -1;
-        break;
-    case 1:
-        tangent.x = bitangent.z = -1;
-        break;
-    case 2:
-        tangent.y = bitangent.z = -1;
-        break;
-    default:
-        break;
-    }
-
-    normal = normalize(normal);
-    if (localSpace)
-    {
-        tangent = normalize(mul((float3x3) unity_ObjectToWorld, tangent));
-        bitangent = normalize(mul((float3x3) unity_ObjectToWorld, bitangent));
-    }
-
-    // give up if the vectors are not linearly independent
-    if (abs(dot(normal, tangent)) < 0.999 && abs(dot(normal, bitangent)) < 0.999)
-    {
-        tangent = tangent - project(tangent, normal);
-        bitangent = bitangent - project(bitangent, normal) - project(bitangent, tangent);
-
-        tangentToWorld[0] = normalize(tangent);
-        tangentToWorld[1] = normalize(bitangent);
-    }
-
-    return tangentToWorld;
 }
 
 void CalculateNormals(v2f i, inout InputData id, float3x3 tangentToWorld, float detailMask){
@@ -468,68 +364,15 @@ void CalculateNormals(v2f i, inout InputData id, float3x3 tangentToWorld, float 
     _NormalStrength *= 1-id.puddleMask;
     _DetailNormalStrength *= 1-id.puddleMask;
 
-    float3 tsNormalBase;
-    float3 tsNormalDetail;
-
-    float3x3 tbnDetail = tangentToWorld;
-
-    // this should be skipped if we're using triplanar sampling – the _UVMainSet property isn't even shown in
-    // the inspector when using this sampling mode
-    #if !defined(_TRIPLANAR_DETAIL_ON) && !(defined(STANDARD_LITE) && defined(_TRIPLANAR_ON))
-    if (_UVDetailSet == 5 || _UVDetailSet == 6)
-    {
-        tbnDetail = calculate_planar_tbn(tangentToWorld, _UVDetailSet == 6, _UVDetailSwizzle);
-    }
-    #endif
-
-    // same rationale as above
-    #if !defined(_TRIPLANAR_ON)
-    if (_UVMainSet == 5 || _UVMainSet == 6)
-    {
-        // Does this save registers vs. creating a new tbnMain variable? I'm guessing it does
-        tangentToWorld = calculate_planar_tbn(tangentToWorld, _UVMainSet == 6, _UVMainSwizzle);
-    }
-    #endif
-
-    #if defined(_NORMALMAP_ON)
-        #if defined(_TRIPLANAR_ON)
-            tsNormalBase = mul(triplanar_normal(_NormalMap, sampler_DefaultSampler, _MainTex_ST, _NormalStrength), transpose(tangentToWorld));
-        #else
-            tsNormalBase = SampleNormalMap(i.uv0.xy);
-        #endif
-    #endif
-    
-    #if defined(_DETAIL_NORMAL_ON)
-        #if defined(_TRIPLANAR_DETAIL_ON) || (defined(STANDARD_LITE) && defined(_TRIPLANAR_ON))
-            // even though this is the detail texture, we need to have all of our normals in the same tangent space – so, use tangentToWorld here
-            tsNormalDetail = mul(triplanar_normal(_DetailNormalMap, sampler_DefaultDetailSampler, _DetailMainTex_ST, _DetailNormalStrength * detailMask), transpose(tangentToWorld));
-        #else
-            tsNormalDetail = SampleDetailNormalMap(i.uv0.zw, detailMask);
-            // we now need to decide if this is the correct tangent-space!
-
-            // if triplanar sampling is enabled for the main texture, then we act like it's using UV0.
-            // otherwise, we check if the UV sources are incompatible: this happens when they aren't equal AND
-            // when they aren't both from a UV map
-            #if defined(_TRIPLANAR_ON)
-                if (_UVDetailSet == 5 || _UVDetailSet == 6)
-            #else
-                if (_UVDetailSet != _UVMainSet && (_UVMainSet >= 5 || _UVDetailSet >= 5))
-            #endif
-                {
-                    tsNormalDetail = mul(tsNormalDetail, tbnDetail);
-                    tsNormalDetail = mul(tsNormalDetail, transpose(tangentToWorld));
-                }
-                    
-        #endif
-    #endif
-    
     #if defined(_NORMALMAP_ON) && !defined(_DETAIL_NORMAL_ON)
-        id.tsNormal = tsNormalBase;
+        id.tsNormal = SampleNormalMap(i.uv0.xy);
     #elif !defined(_NORMALMAP_ON) && defined(_DETAIL_NORMAL_ON)
-        id.tsNormal = tsNormalDetail;
+        id.tsNormal = SampleDetailNormalMap(i.uv0.zw, detailMask);
     #elif defined(_NORMALMAP_ON) && defined(_DETAIL_NORMAL_ON)
-        float3 blendedNormal0 = BlendNormals(tsNormalBase, tsNormalDetail);
-        float3 blendedNormal1 = lerp(tsNormalBase, tsNormalDetail, detailMask);
+        float3 baseNormal = SampleNormalMap(i.uv0.xy);
+        float3 detailNormal = SampleDetailNormalMap(i.uv0.zw, detailMask);
+        float3 blendedNormal0 = BlendNormals(baseNormal, detailNormal);
+        float3 blendedNormal1 = lerp(baseNormal, detailNormal, detailMask);
         id.tsNormal = lerp(blendedNormal0, blendedNormal1, _DetailMaskMode);
     #endif
 

--- a/Mochie/Unity/Editor/StandardEditor.cs
+++ b/Mochie/Unity/Editor/StandardEditor.cs
@@ -25,13 +25,15 @@ namespace Mochie {
             "Render Settings",
             "Debug"
         }, 3);
-        
-        string versionLabel = "v2.9.1";
+
+        string versionLabel = "v2.8";
 
         // Variant Settings
         MaterialProperty _BlendMode = null;
         MaterialProperty _SmoothnessToggle = null;
         MaterialProperty _TriplanarCoordSpace = null;
+        MaterialProperty _TriplanarWorldRotation = null;
+        MaterialProperty _TriplanarWorldOffset = null;
         MaterialProperty _Cutoff = null;
         MaterialProperty _AlphaSource = null;
         MaterialProperty _MipMapRescaling = null;
@@ -335,7 +337,19 @@ namespace Mochie {
         MaterialProperty _FlipBackfaceNormals = null;
 
         // Debug
-        MaterialProperty _DebugFlags = null;
+        MaterialProperty _DebugEnable = null;
+        MaterialProperty _DebugBaseColor = null;
+        MaterialProperty _DebugNormals = null;
+        MaterialProperty _DebugRoughness = null;
+        MaterialProperty _DebugMetallic = null;
+        MaterialProperty _DebugHeight = null;
+        MaterialProperty _DebugVertexColors = null;
+        MaterialProperty _DebugAtten = null;
+        MaterialProperty _DebugReflections = null;
+        MaterialProperty _DebugSpecular = null;
+        MaterialProperty _DebugOcclusion = null;
+        MaterialProperty _DebugAlpha = null;
+        MaterialProperty _DebugLighting = null;
         MaterialProperty _NoiseTexSSR = null;
         MaterialProperty _DefaultSampler = null;
         MaterialProperty _DefaultDetailSampler = null;
@@ -449,7 +463,18 @@ namespace Mochie {
                         }
                         me.ShaderProperty(_SmoothnessToggle, Tips.smoothnessModeText);
                         if (_PrimarySampleMode.floatValue == 3 || (_DetailSampleMode.floatValue == 3 && !isLite))
+                        {
                             me.ShaderProperty(_TriplanarCoordSpace, "Triplanar Coordinates");
+
+                            if (_TriplanarCoordSpace.floatValue == 1)
+                            {
+                                MGUI.PropertyGroup(() => {
+                                    MGUI.Vector3Field(_TriplanarWorldRotation, "World Rotation", false);
+                                    MGUI.Vector3Field(_TriplanarWorldOffset, "World Offset", false);
+                                });
+                            }
+                        }
+
                     });
                     if (_BlendMode.floatValue == 1){
                         MGUI.PropertyGroup(()=>{
@@ -746,9 +771,6 @@ namespace Mochie {
         #region Vertex Manip
         void DoVertexManipulation(Material mat){
             if (Foldouts.DoFoldout(foldouts, mat, me, _VertexManipulationToggle, "Vertex Manipulation", Foldouts.Style.ThinLongToggle)){
-                MGUI.Space6();
-                MGUI.DisplayWarning("Please note that meshes set to 'batching static' may exhibit different behavior at runtime when using wind or rotation settings, it is recommended to use GPU instancing for these meshes instead. To do this: disable 'batching static' in the static toggle dropdown for the object, then tick 'Enable GPU Instancing' in the render settings for this material.");
-                MGUI.SpaceN4();
                 MGUI.PropertyGroupParent(()=>{
                     MGUI.ToggleGroup(_VertexManipulationToggle.floatValue == 0);
                     MGUI.PropertyGroup(()=>{
@@ -793,10 +815,13 @@ namespace Mochie {
                                 me.ShaderProperty(_WindSmoothness2, "Smoothness");
                             });
                         }
+                        if (_WindToggle.floatValue == 1){
+                            MGUI.DisplayWarning("Please note that meshes set to 'batching static' may exhibit different wind behavior at runtime, it is recommended to use GPU instancing for these meshes instead.");
+                            MGUI.SpaceN1();
+                        }
                     });
                     MGUI.ToggleGroupEnd();
                 });
-                MGUI.ToggleGroupEnd();
             }
         }
         #endregion
@@ -875,7 +900,7 @@ namespace Mochie {
                 me.ShaderProperty(_RippleSpeed, "Speed");
                 me.ShaderProperty(_RippleDensity, "Density");
                 me.ShaderProperty(_RippleSize, "Size");
-                me.ShaderProperty(_RippleHorizonAdjustment, Tips.horizonAdjustmentText);
+                me.ShaderProperty(_RippleHorizonAdjustment, "Horizon Adjustment");
                 me.ShaderProperty(_RippleHorizonAdjustmentDistance, "Adjustment Distance");
             });
             if (_PuddleToggle.floatValue == 1){
@@ -1219,7 +1244,7 @@ namespace Mochie {
         void DoRenderSettings(Material mat){
             if (Foldouts.DoFoldout(foldouts, mat, "Render Settings", Foldouts.Style.ThinLong)){
                 MGUI.PropertyGroupParent(()=>{
-                    MGUI.PropertyGroup(()=>{
+                    MGUI.PropertyGroup(() => {
                         me.ShaderProperty(_Culling, Tips.culling);
                         _QueueOffset.floatValue = (int)_QueueOffset.floatValue;
                         me.ShaderProperty(_QueueOffset, Tips.queueOffset);
@@ -1247,8 +1272,21 @@ namespace Mochie {
             if (_MaterialDebugMode.floatValue == 1){
                 if (Foldouts.DoFoldout(foldouts, mat, "Debug", Foldouts.Style.ThinLong)){
                     MGUI.PropertyGroupParent(()=>{
-                        MGUI.EnumDropdown<DebugFlags>(_DebugFlags, new GUIContent("Debug View"));
-
+                        MGUI.ShaderPropertyBold(me, _DebugEnable, "Debug View");
+                        MGUI.PropertyGroup(()=>{
+                            me.ShaderProperty(_DebugBaseColor, "Base Color");
+                            me.ShaderProperty(_DebugAlpha, "Alpha");
+                            me.ShaderProperty(_DebugNormals, "Normals");
+                            me.ShaderProperty(_DebugRoughness, "Roughness");
+                            me.ShaderProperty(_DebugMetallic, "Metallic");
+                            me.ShaderProperty(_DebugOcclusion, "Occlusion");
+                            me.ShaderProperty(_DebugHeight, "Height");
+                            me.ShaderProperty(_DebugLighting, "Lighting");
+                            me.ShaderProperty(_DebugAtten, "Realtime Shadows");
+                            me.ShaderProperty(_DebugReflections, "Reflections");
+                            me.ShaderProperty(_DebugSpecular, "Specular Highlights");
+                            me.ShaderProperty(_DebugVertexColors, "Vertex Colors");
+                        });		
                         MGUI.BoldLabel("Default Textures");
                         MGUI.PropertyGroup(()=>{
                             me.TexturePropertySingleLine(new GUIContent("LUT for Filament SM"), _DFG);


### PR DESCRIPTION
This will add World Rotation and World Offset for X, Y and Z Coordinates when using Triplanar Sampling. However, this was for 2.8 i didnt saw 2.9 Exists.